### PR TITLE
issue 44: Accessor approach to remake

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,8 +1,8 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.11.6"
+julia_version = "1.11.7"
 manifest_format = "2.0"
-project_hash = "e891ce30fc8b99bfe508936aa602b084d0e46920"
+project_hash = "c3cfdac23c1650de4a33afd2230934b49fc45f2d"
 
 [[deps.ADTypes]]
 git-tree-sha1 = "60665b326b75db6517939d0e1875850bc4a54368"

--- a/Project.toml
+++ b/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"

--- a/index.qmd
+++ b/index.qmd
@@ -171,7 +171,7 @@ end
 
 
 ```{julia}
-using Turing: filldist
+using Turing: arraydist
 arma_model = update_fields(ar2_model;
             damp_prior=arraydist([truncated(Normal(0.8, 0.1), 0, 1),
                                     truncated(Normal(0.1, 0.05), 0, 1)]),

--- a/index.qmd
+++ b/index.qmd
@@ -133,6 +133,7 @@ display(ar_model)
 This default constructor returns the AR(1), we can also construct AR(p)
 
 ```{julia}
+using Distributions
 ar2_model = AR(Normal(), Normal(); p = 2)
 display(ar2_model)
 ```
@@ -144,7 +145,6 @@ $$Z_t = \epsilon_t + \theta \epsilon_{t-1}, \quad \epsilon_t \sim \text{Normal}(
 The `MA` struct encapsulates this:
 
 ```{julia}
-using Distributions
 ma_model = MA(;
     θ_priors=[truncated(Normal(0.0, 0.05), -1, 1)],
     ϵ_t=HierarchicalNormal(std_prior=HalfNormal(0.5))

--- a/index.qmd
+++ b/index.qmd
@@ -130,6 +130,13 @@ ar_model = AR()
 display(ar_model)
 ```
 
+This default constructor returns the AR(1), we can also construct AR(p)
+
+```{julia}
+ar2_model = AR(Normal(), Normal(); p = 2)
+display(ar2_model)
+```
+
 Another common latent model is the moving average model
 
 $$Z_t = \epsilon_t + \theta \epsilon_{t-1}, \quad \epsilon_t \sim \text{Normal}(0, \sigma)$$
@@ -152,12 +159,24 @@ $$Z_t = \rho_1 Z_{t-1} + \rho_2 Z_{t-2} + \epsilon_t + \theta \epsilon_{t-1}$$
 In our DSL this can be represented as a composition of the AR and MA structs by passing MA as the error term to AR:
 
 ```{julia}
-arma_model = AR(;
-    damp_priors=[truncated(Normal(0.8, 0.1), 0, 1),
-        truncated(Normal(0.1, 0.05), 0, 1)],
-    init_priors=[Normal(-1.0, 0.1), Normal(-1.0, 0.5)],
-    ϵ_t=ma_model
-)
+using Accessors
+function update_fields(obj; kwargs...)
+    result = obj
+    for (key, value) in kwargs
+        result = set(result, PropertyLens(key), value)
+    end
+    return result
+end
+```
+
+
+```{julia}
+using Turing: filldist
+arma_model = update_fields(ar2_model;
+            damp_prior=arraydist([truncated(Normal(0.8, 0.1), 0, 1),
+                                    truncated(Normal(0.1, 0.05), 0, 1)]),
+            init_prior = arraydist([Normal(-1.0, 0.1), Normal(-1.0, 0.5)]),
+            ϵ_t=ma_model)
 ```
 
 Similarly, autoregressive integrated moving average (ARIMA) models extend ARMA by adding differencing for non-stationary series:


### PR DESCRIPTION
This draft PR offers an option for #44 

```julia
using Accessors
function update_fields(obj; kwargs...)
    result = obj
    for (key, value) in kwargs
        result = set(result, PropertyLens(key), value)
    end
    return result
end
```

I think this is fairly neat, however a quick experimentation shows that there is still a bit of pain. 

## Downsides

The main friction point is that you can't go between different values of `p` without invoking problems.

eg. 

```julia
using EpiAware
ar_model = AR()
display(ar_model)
```

```julia
using Turing: arraydist
arma_model = update_fields(ar_model;
            damp_prior=arraydist([truncated(Normal(0.8, 0.1), 0, 1),
                                    truncated(Normal(0.1, 0.05), 0, 1)]),
            init_prior = arraydist([Normal(-1.0, 0.1), Normal(-1.0, 0.5)]),
            ϵ_t=ma_model)
```

fails because it can't sequentially set the field values in a valid way (they violate type checking) and `Accessor` isn't aimed at batch remaking.

So you need an intermediate 

```julia
using Distributions
ar2_model = AR(Normal(), Normal(); p = 2)
display(ar2_model)
```

```julia
using Turing: arraydist
arma_model = update_fields(ar2_model;
            damp_prior=arraydist([truncated(Normal(0.8, 0.1), 0, 1),
                                    truncated(Normal(0.1, 0.05), 0, 1)]),
            init_prior = arraydist([Normal(-1.0, 0.1), Normal(-1.0, 0.5)]),
            ϵ_t=ma_model)
```
